### PR TITLE
Update new line spacing for examples

### DIFF
--- a/src/content/project/cachestore.md
+++ b/src/content/project/cachestore.md
@@ -155,6 +155,8 @@ struct ContentView: View {
 ```
 
 </details>
+  
+<br/>
 
 <details> 
   <summary>Testing</summary> 
@@ -208,7 +210,8 @@ class CacheStoreDemoTests: XCTestCase {
 ```
 
 </details>
-***
+  
+<br/>
 
 ### [Visit the Github Repo](https://github.com/0xOpenBytes/cachestore)
 <br/>


### PR DESCRIPTION
We should have the basic usage examples on their own lines.

![Screenshot 2023-02-13 at 4 31 34 PM](https://user-images.githubusercontent.com/8268288/218598082-edc787ed-200a-4d9e-ab7d-75d9355f67c5.png)
