### PR TITLE
feat: adds TelemetryDeck analytics

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -90,6 +90,10 @@ const fallbackImageURL = new URL(SITE.ogImage, Astro.url.origin).href;
     }
 
     <script is:inline src="/toggle-theme.js"></script>
+    <script
+      src="https://cdn.telemetrydeck.com/websdk/telemetrydeck.min.js"
+      data-app-id="A78D83D0-1E59-482C-9A87-7488D8837752"
+    ></script>
   </head>
   <body>
     <slot />


### PR DESCRIPTION
This feature adds TelemetryDeck to our website in the header. This means that anywhere that the `Header.astro` file is called, we will be receiving a TelemetryDeck Signal. In the signal, we see who the `referrer` is, which is the page the user tapped.